### PR TITLE
[feat]get missing maintenance lesson

### DIFF
--- a/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
@@ -20,6 +20,8 @@ public enum SuccessStatus {
     UPDATE_LESSON_PARENTS_SUCCESS(HttpStatus.OK, "수업과 학부모 연결 성공"),
     GET_TODAY_SCHEDULE_BY_TEACHER_SUCCESS(HttpStatus.OK, "선생님 메인 뷰의 오늘의 수업 배너를 가져오는데 성공했습니다."),
     GET_SCHEDULE_BY_USER_SUCCESS(HttpStatus.OK, "스케줄 메인 뷰를 가져오는데 성공했습니다."),
+    GET_MISSING_MAINTENANCE_LESSON_SUCCESS(HttpStatus.OK, "연장여부를 알려주지 않은 수업 리스트 가져오기 성공"),
+
 
     /**
      * 201 CREATED

--- a/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
@@ -26,7 +26,8 @@ public enum SuccessStatus {
      */
     SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입이 완료됐습니다."),
     CREATE_LESSON_SUCCESS(HttpStatus.CREATED, "수업 생성이 완료됐습니다."),
-
+    AUTO_CREATE_SCHEDULE_FROM_LESSON_MAINTENANCE_SUCCESS(HttpStatus.CREATED,"수업 연장으로 다음 사이클 스케쥴 자동생성 성공"),
+    FINISH_LESSON_SUCCESS(HttpStatus.CREATED,"수업 종료 성공"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
@@ -21,8 +21,6 @@ public enum SuccessStatus {
     GET_TODAY_SCHEDULE_BY_TEACHER_SUCCESS(HttpStatus.OK, "선생님 메인 뷰의 오늘의 수업 배너를 가져오는데 성공했습니다."),
     GET_SCHEDULE_BY_USER_SUCCESS(HttpStatus.OK, "스케줄 메인 뷰를 가져오는데 성공했습니다."),
     GET_MISSING_ATTENDANCE_SCHEDULE_SUCCESS(HttpStatus.OK, "선생님의 출결 누락 뷰를 가져오는데 성공했습니다."),
-    AUTO_CREATE_SCHEDULE_FROM_LESSON_MAINTENANCE_SUCCESS(HttpStatus.CREATED,"수업 연장으로 다음 사이클 스케쥴 자동생성 성공"),
-    FINISH_LESSON_SUCCESS(HttpStatus.CREATED,"수업 종료 성공"),
     GET_MISSING_MAINTENANCE_LESSON_SUCCESS(HttpStatus.OK, "연장여부를 알려주지 않은 수업 리스트 가져오기 성공"),
 
 

--- a/src/main/java/gwasuwonshot/tutice/common/module/DateAndTimeConvert.java
+++ b/src/main/java/gwasuwonshot/tutice/common/module/DateAndTimeConvert.java
@@ -5,9 +5,6 @@ import gwasuwonshot.tutice.lesson.exception.InvalidDateException;
 import gwasuwonshot.tutice.lesson.exception.InvalidTimeException;
 
 import java.time.LocalDate;
-
-import java.sql.Date;
-import java.sql.Time;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
@@ -16,7 +13,7 @@ import java.util.Locale;
 public class DateAndTimeConvert {
 
     public static String nowLocalDateConvertString(){
-        //현재날짜를 'yyyy-mm-dd'에 형식의 string으로 만들어주기
+        //현재날짜를 'yyyy-mm-dd' 형식의 string으로 만들어주기
         LocalDate nowDate = LocalDate.now();
         return nowDate.toString();
     }

--- a/src/main/java/gwasuwonshot/tutice/lesson/controller/LessonController.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/controller/LessonController.java
@@ -9,6 +9,7 @@ import gwasuwonshot.tutice.lesson.dto.request.UpdateLessonParentsRequestDto;
 import gwasuwonshot.tutice.lesson.dto.response.CreateLessonResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.GetLessonByUserResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.GetLessonDetailByParentsResponseDto;
+import gwasuwonshot.tutice.lesson.dto.response.GetMissingMaintenanceLessonDto;
 import gwasuwonshot.tutice.lesson.service.LessonService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -97,6 +98,21 @@ public class LessonController {
             return ApiResponseDto.success(SuccessStatus.FINISH_LESSON_SUCCESS);
 
         }
+
+
+    }
+
+
+
+
+    @GetMapping("/maintenance/missing")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetMissingMaintenanceLessonDto> getMissingMaintenanceLesson(@UserIdx final Long userIdx) {
+
+
+        return ApiResponseDto.success(SuccessStatus.GET_MISSING_MAINTENANCE_LESSON_SUCCESS,
+                GetMissingMaintenanceLessonDto.of(lessonService.getMissingMaintenanceLesson(userIdx))
+        );
 
 
     }

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/GetMissingMaintenanceLesson.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/GetMissingMaintenanceLesson.java
@@ -1,0 +1,21 @@
+package gwasuwonshot.tutice.lesson.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMissingMaintenanceLesson {
+    private MissingMaintenanceLesson lesson;
+    private String endScheduleDate; //"2023-05-25"
+
+    public static GetMissingMaintenanceLesson of(MissingMaintenanceLesson lesson, String endScheduleDate) {
+        return new GetMissingMaintenanceLesson(lesson, endScheduleDate);
+
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/GetMissingMaintenanceLessonDto.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/GetMissingMaintenanceLessonDto.java
@@ -1,0 +1,20 @@
+package gwasuwonshot.tutice.lesson.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMissingMaintenanceLessonDto {
+    private List<GetMissingMaintenanceLesson> missingMaintenanceLessonList;
+    public static GetMissingMaintenanceLessonDto of(List<GetMissingMaintenanceLesson> missingMaintenanceLessonList) {
+        return new GetMissingMaintenanceLessonDto(missingMaintenanceLessonList);
+
+    }
+}
+

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/MissingMaintenanceLesson.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/MissingMaintenanceLesson.java
@@ -1,0 +1,23 @@
+package gwasuwonshot.tutice.lesson.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MissingMaintenanceLesson {
+    private Long idx;
+    private String studentName;
+    private String subject;
+    private Long count;
+
+    public static MissingMaintenanceLesson of(Long idx, String studentName, String subject, Long count) {
+        return new MissingMaintenanceLesson(idx, studentName, subject, count);
+
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/repository/LessonRepository.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/repository/LessonRepository.java
@@ -10,5 +10,7 @@ public interface LessonRepository extends JpaRepository<Lesson, Long> {
 
     List<Lesson> findAllByParentsIdx(Long parentsIdx);
 
+    List<Lesson> findAllByTeacherIdxAndIsFinished(Long teacherIdx, Boolean isFinished);
+
 }
 

--- a/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
@@ -20,5 +20,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Schedule findTopByLessonOrderByDateDesc(Lesson lesson);
 
+    Schedule findTopByLessonAndStatusNotOrderByDateDesc(Lesson lesson,ScheduleStatus status);
+
 
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
closes #51 


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- 유저 역할검사
- 유저가 teacher로 연결된 레슨중 isFinished가 false인 레슨 리스트 가져오기
- 위의 레슨들에 연결된 스케쥴중 가장 최근 스케쥴(마지막스케쥴)이 출결사항이 존재하는 레슨 ->이 연장하지 않은 레슨



<br/>


### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
