### PR TITLE
[feat]get lesson payment record by parents

### DIFF
--- a/src/main/java/gwasuwonshot/tutice/lesson/controller/PaymentRecordController.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/controller/PaymentRecordController.java
@@ -9,9 +9,12 @@ import gwasuwonshot.tutice.lesson.dto.request.UpdateLessonParentsRequestDto;
 import gwasuwonshot.tutice.lesson.dto.request.UpdatePaymentRecordRequestDto;
 import gwasuwonshot.tutice.lesson.dto.request.createLesson.CreateLessonRequestDto;
 import gwasuwonshot.tutice.lesson.dto.response.CreateLessonResponseDto;
+import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord.GetPaymentRecordByParentsResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord.GetPaymentRecordByTeacherResponseDto;
+import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord.GetPaymentRecordByUserResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecordView.GetPaymentRecordViewResponseDto;
 import gwasuwonshot.tutice.lesson.service.PaymentRecordService;
+import gwasuwonshot.tutice.user.entity.Role;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -56,13 +59,27 @@ public class PaymentRecordController {
 
     @GetMapping("/teacher/{lessonIdx}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<GetPaymentRecordByTeacherResponseDto> getLessonPaymentRecordByTeacher(
+    public ApiResponseDto<GetPaymentRecordByUserResponseDto> getLessonPaymentRecordByTeacher(
             @UserIdx final Long userIdx,
             @PathVariable final Long lessonIdx) {
 
 
         return ApiResponseDto.success(SuccessStatus.GET_PAYMENT_RECORD_SUCCESS,
-                paymentRecordService.getLessonPaymentRecordByTeacher(userIdx,lessonIdx));
+                paymentRecordService.getLessonPaymentRecordByUser(Role.TEACHER,userIdx,lessonIdx));
+
+
+    }
+
+
+    @GetMapping("/parents/{lessonIdx}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetPaymentRecordByUserResponseDto> getLessonPaymentRecordByParents(
+            @UserIdx final Long userIdx,
+            @PathVariable final Long lessonIdx) {
+
+
+        return ApiResponseDto.success(SuccessStatus.GET_PAYMENT_RECORD_SUCCESS,
+                paymentRecordService.getLessonPaymentRecordByUser(Role.PARENTS, userIdx,lessonIdx));
 
 
     }

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordByParentsResponseDto.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordByParentsResponseDto.java
@@ -1,6 +1,5 @@
 package gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord;
 
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,14 +10,13 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class GetPaymentRecordByTeacherResponseDto implements GetPaymentRecordByUserResponseDto{
-    private GetPaymentRecordLessonByTeacher lesson;
+public class GetPaymentRecordByParentsResponseDto implements GetPaymentRecordByUserResponseDto{
+    private GetPaymentRecordLessonByParents lesson;
     private String todayDate;
     private List<GetPaymentRecord> paymentRecordList;
 
-    public static GetPaymentRecordByTeacherResponseDto of(GetPaymentRecordLessonByTeacher lesson, String todayDate, List<GetPaymentRecord> paymentRecordList) {
-        return new GetPaymentRecordByTeacherResponseDto(lesson, todayDate, paymentRecordList);
+    public static GetPaymentRecordByParentsResponseDto of(GetPaymentRecordLessonByParents lesson, String todayDate, List<GetPaymentRecord> paymentRecordList) {
+        return new GetPaymentRecordByParentsResponseDto(lesson, todayDate, paymentRecordList);
     }
-
 }
 

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordByUserResponseDto.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordByUserResponseDto.java
@@ -1,0 +1,4 @@
+package gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord;
+
+public interface GetPaymentRecordByUserResponseDto {
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordLessonByParents.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordLessonByParents.java
@@ -1,0 +1,23 @@
+package gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPaymentRecordLessonByParents {
+    private Long idx;
+    private String studentName;
+    private String teacherName;
+    private String subject;
+
+    public static GetPaymentRecordLessonByParents of(Long idx, String studentName,String teacherName, String subject) {
+        return new GetPaymentRecordLessonByParents(idx, studentName,teacherName ,subject);
+    }
+
+
+
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordLessonByTeacher.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getPaymentRecord/GetPaymentRecordLessonByTeacher.java
@@ -5,17 +5,15 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class GetPaymentRecordLesson {
+public class GetPaymentRecordLessonByTeacher {
     private Long idx;
     private String studentName;
     private String subject;
 
-    public static GetPaymentRecordLesson of(Long idx,String studentName,String subject) {
-        return new GetPaymentRecordLesson(idx, studentName, subject);
+    public static GetPaymentRecordLessonByTeacher of(Long idx, String studentName, String subject) {
+        return new GetPaymentRecordLessonByTeacher(idx, studentName, subject);
     }
 }

--- a/src/main/java/gwasuwonshot/tutice/lesson/entity/Lesson.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/entity/Lesson.java
@@ -111,6 +111,7 @@ public class Lesson extends AuditingTimeEntity {
 
     public void finishLesson(){this.isFinished=true;}
     public Boolean isMatchedParents(User parents){
+        if(this.getParents() == null ){return false;}
         return this.getParents().equals(parents);
     }
 

--- a/src/main/java/gwasuwonshot/tutice/lesson/service/PaymentRecordService.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/service/PaymentRecordService.java
@@ -3,33 +3,24 @@ package gwasuwonshot.tutice.lesson.service;
 
 import gwasuwonshot.tutice.common.exception.ErrorStatus;
 import gwasuwonshot.tutice.common.module.DateAndTimeConvert;
-import gwasuwonshot.tutice.lesson.dto.assembler.LessonAssembler;
-import gwasuwonshot.tutice.lesson.dto.assembler.PaymentRecordAssembler;
-import gwasuwonshot.tutice.lesson.dto.assembler.RegularScheduleAssembler;
-import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord.GetPaymentRecord;
-import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord.GetPaymentRecordByTeacherResponseDto;
-import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord.GetPaymentRecordLesson;
+import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecord.*;
 import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecordView.GetPaymentRecordViewCycle;
 import gwasuwonshot.tutice.lesson.dto.response.getPaymentRecordView.GetPaymentRecordViewLesson;
 import gwasuwonshot.tutice.lesson.entity.Lesson;
 import gwasuwonshot.tutice.lesson.entity.PaymentRecord;
-import gwasuwonshot.tutice.lesson.entity.RegularSchedule;
 import gwasuwonshot.tutice.lesson.exception.invalid.InvalidLessonException;
 import gwasuwonshot.tutice.lesson.exception.invalid.InvalidPaymentRecordException;
 import gwasuwonshot.tutice.lesson.exception.notfound.NotFoundLessonException;
 import gwasuwonshot.tutice.lesson.exception.notfound.NotFoundPaymentRecordException;
 import gwasuwonshot.tutice.lesson.repository.LessonRepository;
 import gwasuwonshot.tutice.lesson.repository.PaymentRecordRepository;
-import gwasuwonshot.tutice.lesson.repository.RegularScheduleRepository;
 import gwasuwonshot.tutice.schedule.entity.Schedule;
 import gwasuwonshot.tutice.schedule.entity.ScheduleStatus;
 import gwasuwonshot.tutice.schedule.repository.ScheduleRepository;
-import gwasuwonshot.tutice.user.dto.assembler.AccountAssembler;
 import gwasuwonshot.tutice.user.entity.Role;
 import gwasuwonshot.tutice.user.entity.User;
 import gwasuwonshot.tutice.user.exception.userException.InvalidRoleException;
 import gwasuwonshot.tutice.user.exception.userException.NotFoundUserException;
-import gwasuwonshot.tutice.user.repository.AccountRepository;
 import gwasuwonshot.tutice.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -47,49 +38,49 @@ public class PaymentRecordService {
     private final ScheduleRepository scheduleRepository;
 
     @Transactional
-    public GetPaymentRecordViewLesson getPaymentRecordView(Long userIdx, Long paymentRecordIdx){
+    public GetPaymentRecordViewLesson getPaymentRecordView(Long userIdx, Long paymentRecordIdx) {
         //1. 유저가 선생님인지 확인
         User teacher = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
-        if(!teacher.isMatchedRole(Role.TEACHER)){
-            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
+        if (!teacher.isMatchedRole(Role.TEACHER)) {
+            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION, ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
         }
 
         //2. 파라미터로 들어오는 paymentRecordIdx가 존재하는지 확인
         PaymentRecord paymentRecord = paymentRecordRepository.findById(paymentRecordIdx)
-                .orElseThrow(() -> new NotFoundPaymentRecordException(ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION,ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION.getMessage()));
+                .orElseThrow(() -> new NotFoundPaymentRecordException(ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION, ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION.getMessage()));
 
-        Lesson lesson= paymentRecord.getLesson();
+        Lesson lesson = paymentRecord.getLesson();
 
 
         //3. paymentRecordIdx의 레슨이 선생님의 레슨인지 확인
-        if(!lesson.isMatchedTeacher(teacher)){
-            throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION,ErrorStatus.INVALID_LESSON_EXCEPTION.getMessage());
+        if (!lesson.isMatchedTeacher(teacher)) {
+            throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_EXCEPTION.getMessage());
 
         }
         // 해당레슨의 사이클 확인,  레슨 사이클의 처음스케쥴데이트 가장 늦은 스케쥴데이트 가져오기
-            //regularScheduleList를 요일순서로 정렬
-        Collections.sort( lesson.getPaymenRecordList(), new Comparator<PaymentRecord>() {
+        //regularScheduleList를 요일순서로 정렬
+        Collections.sort(lesson.getPaymenRecordList(), new Comparator<PaymentRecord>() {
             @Override
             public int compare(PaymentRecord o1, PaymentRecord o2) {
-                    //정렬목표 : 오름차순 : 오래된순
-                    if(o1.getCreatedAt().isAfter(o2.getCreatedAt())){
-                        return 1;
-                    }
-                    return -1;
+                //정렬목표 : 오름차순 : 오래된순
+                if (o1.getCreatedAt().isAfter(o2.getCreatedAt())) {
+                    return 1;
                 }
-            });
+                return -1;
+            }
+        });
 
         // 들아오는 paymentRecord로 사이클판단
-            Long cycle = Long.valueOf(lesson.getPaymenRecordList().indexOf(paymentRecord))+1;
+        Long cycle = Long.valueOf(lesson.getPaymenRecordList().indexOf(paymentRecord)) + 1;
 
-            if(cycle == -1){
-                throw new InvalidPaymentRecordException(ErrorStatus.UNCONNECTED_LESSON_PAYMENT_RECORD_EXCEPTION,ErrorStatus.UNCONNECTED_LESSON_PAYMENT_RECORD_EXCEPTION.getMessage());
-            }
+        if (cycle == -1) {
+            throw new InvalidPaymentRecordException(ErrorStatus.UNCONNECTED_LESSON_PAYMENT_RECORD_EXCEPTION, ErrorStatus.UNCONNECTED_LESSON_PAYMENT_RECORD_EXCEPTION.getMessage());
+        }
 
-        Schedule endSchedule = scheduleRepository.findTopByLessonAndCycleAndStatusNotOrderByDateDesc(lesson,cycle, ScheduleStatus.CANCEL);
-        Schedule startSchedule = scheduleRepository.findTopByLessonAndCycleAndStatusNotOrderByDateAsc(lesson,cycle, ScheduleStatus.CANCEL);
+        Schedule endSchedule = scheduleRepository.findTopByLessonAndCycleAndStatusNotOrderByDateDesc(lesson, cycle, ScheduleStatus.CANCEL);
+        Schedule startSchedule = scheduleRepository.findTopByLessonAndCycleAndStatusNotOrderByDateAsc(lesson, cycle, ScheduleStatus.CANCEL);
 
         return GetPaymentRecordViewLesson.of(lesson.getIdx(), lesson.getStudentName(), lesson.getSubject(),
                 GetPaymentRecordViewCycle.of(cycle,
@@ -99,29 +90,28 @@ public class PaymentRecordService {
     }
 
 
-
     @Transactional
-    public void updatePaymentRecord(Long userIdx, Long paymentRecordIdx, LocalDate paymentDate){
+    public void updatePaymentRecord(Long userIdx, Long paymentRecordIdx, LocalDate paymentDate) {
 //        유저의 역할이 선생님이 맞나요?
         User teacher = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
-        if(!teacher.isMatchedRole(Role.TEACHER)){
-            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
+        if (!teacher.isMatchedRole(Role.TEACHER)) {
+            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION, ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
         }
 //        들어오는 페이먼트레코드 아이디가 존재하고 해당 레코드의 레슨이 선생님것이 맞나요?
 
-        PaymentRecord paymentRecord =paymentRecordRepository.findById(paymentRecordIdx)
-                .orElseThrow(()-> new NotFoundPaymentRecordException(ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION, ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION.getMessage()));
+        PaymentRecord paymentRecord = paymentRecordRepository.findById(paymentRecordIdx)
+                .orElseThrow(() -> new NotFoundPaymentRecordException(ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION, ErrorStatus.NOT_FOUND_PAYMENT_RECORD_EXCEPTION.getMessage()));
 
         //3. 이 레슨이 선생님의 레슨인지 확인
-        if(!paymentRecord.getLesson().isMatchedTeacher(teacher)){
-            throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION,ErrorStatus.INVALID_LESSON_EXCEPTION.getMessage());
+        if (!paymentRecord.getLesson().isMatchedTeacher(teacher)) {
+            throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_EXCEPTION.getMessage());
         }
 
         // paymentRecord가 이미 입금되었는지 여부
-        if(paymentRecord.isRecorded()){
-            throw new InvalidPaymentRecordException(ErrorStatus.INVALID_PAYMENT_RECORD_EXCEPTION,ErrorStatus.INVALID_PAYMENT_RECORD_EXCEPTION.getMessage());
+        if (paymentRecord.isRecorded()) {
+            throw new InvalidPaymentRecordException(ErrorStatus.INVALID_PAYMENT_RECORD_EXCEPTION, ErrorStatus.INVALID_PAYMENT_RECORD_EXCEPTION.getMessage());
         }
 
 
@@ -132,75 +122,106 @@ public class PaymentRecordService {
     }
 
 
-
-
     @Transactional
-    public GetPaymentRecordByTeacherResponseDto getLessonPaymentRecordByTeacher(Long userIdx, Long lessonIdx){
-        // 유저의 역할이 선생님이 맞나요?
-        User teacher = userRepository.findById(userIdx)
+    public GetPaymentRecordByUserResponseDto getLessonPaymentRecordByUser(Role role, Long userIdx, Long lessonIdx) {
+        // 유저의 역할이 부모님이 맞나요?
+        User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
-        if(!teacher.isMatchedRole(Role.TEACHER)){
-            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
+        if (!user.isMatchedRole(role)) {
+            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION, ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
         }
+
         // 레슨의 존재확인
-        Lesson lesson=lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findById(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
 
+
+
         // 레슨과 유저의 연결성확인
-        if(!lesson.isMatchedTeacher(teacher)){
-            throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
+        // TODO if문 depth 리팩필요
+        if(role.equals(Role.TEACHER)){
+            if (!lesson.isMatchedTeacher(user)) {
+                throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
+            }
+        } else if (role.equals(Role.PARENTS)) {
+
+            if (!lesson.isMatchedParents(user)) {
+                throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
+            }
+
+        } else {
+            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION, ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
+
         }
+
 
         // 레슨의 현재 사이클 확인
         //    스케쥴테이블에서 현재사이클의 가장 최신 스케쥴이 출결이면(상태없음이 아니면)(어차피 취소는 생각안해도됨�) ->사이클이마무리된거로판단
 
-        Schedule lastestSchedule = scheduleRepository.findTopByLessonAndCycleAndStatusNotOrderByDateDesc(lesson,lesson.getCycle(), ScheduleStatus.CANCEL);
+        Schedule lastestSchedule = scheduleRepository.findTopByLessonAndCycleAndStatusNotOrderByDateDesc(lesson, lesson.getCycle(), ScheduleStatus.CANCEL);
 
 
         // 최신 순으로 정렬
-        Collections.sort( lesson.getPaymenRecordList(), new Comparator<PaymentRecord>() {
+        Collections.sort(lesson.getPaymenRecordList(), new Comparator<PaymentRecord>() {
             @Override
             public int compare(PaymentRecord o1, PaymentRecord o2) {
                 //정렬목표 : 내림차순 : 최신순
-                if(o1.getCreatedAt().isAfter(o2.getCreatedAt())){
+                if (o1.getCreatedAt().isAfter(o2.getCreatedAt())) {
                     return -1;
                 }
                 return 1;
             }
         });
 
-        List<GetPaymentRecord> paymentRecordList=new ArrayList<>();
 
-        if(lastestSchedule.isMatchedStatus(ScheduleStatus.NO_STATUS)){
+        List<GetPaymentRecord> paymentRecordList = new ArrayList<>();
+
+        if (lastestSchedule.isMatchedStatus(ScheduleStatus.NO_STATUS)) {
             // - [ ] 아니면, 사이클-1개수로 가져오기
-            lesson.getPaymenRecordList().subList(0,lesson.getCycle().intValue()-1)
-                    .forEach(pr->{
-                        paymentRecordList.add(
-                                GetPaymentRecord.of(
-                                        pr.getIdx(), (pr.getDate()==null) ? null : DateAndTimeConvert.localDateConvertString(pr.getDate()),pr.getAmount(),pr.getStatus()));
-                    }
-            );
-        }
-        else {
+            lesson.getPaymenRecordList().subList(0, lesson.getCycle().intValue() - 1)
+                    .forEach(pr -> {
+                                paymentRecordList.add(
+                                        GetPaymentRecord.of(
+                                                pr.getIdx(), (pr.getDate() == null) ? null : DateAndTimeConvert.localDateConvertString(pr.getDate()), pr.getAmount(), pr.getStatus()));
+                            }
+                    );
+        } else {
             //- [ ] 사이클개수대로 payment 가져오기
-            lesson.getPaymenRecordList().forEach(pr->{
+            lesson.getPaymenRecordList().forEach(pr -> {
                 paymentRecordList.add(
                         GetPaymentRecord.of(
-                                pr.getIdx(), DateAndTimeConvert.localDateConvertString(pr.getDate()),pr.getAmount(),pr.getStatus()));
+                                pr.getIdx(), DateAndTimeConvert.localDateConvertString(pr.getDate()), pr.getAmount(), pr.getStatus()));
             });
         }
 
+        if (role.equals(Role.TEACHER)) {
+            return GetPaymentRecordByTeacherResponseDto.of(
+                    GetPaymentRecordLessonByTeacher.of(
+                            lesson.getIdx(), lesson.getStudentName(), lesson.getSubject()),
+                    DateAndTimeConvert.nowLocalDateConvertString(),
+                    paymentRecordList
+            );
+
+        } else if (role.equals(Role.PARENTS)) {
+            return GetPaymentRecordByParentsResponseDto.of(
+                    GetPaymentRecordLessonByParents.of(
+                            lesson.getIdx(), lesson.getStudentName(), lesson.getTeacher().getName(), lesson.getSubject()),
+                    DateAndTimeConvert.nowLocalDateConvertString(),
+                    paymentRecordList
+            );
+
+        }
+
+        return null;
 
 
-
-        return GetPaymentRecordByTeacherResponseDto.of(
-                GetPaymentRecordLesson.of(
-                        lesson.getIdx(), lesson.getStudentName(), lesson.getSubject()),
-                DateAndTimeConvert.nowLocalDateConvertString(),
-                paymentRecordList
-        );
     }
+
 }
+
+
+
+
 
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
closes #82


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- 이전에 구현한 선생님의 수업내역뷰중 입금내역뷰와 학부모를 동일하게 가져가기위해 GetLessonPaymentRecordByUser interface 제작
- 서비스단의 동일한 로직을 위해 Role 값을 파라미터에 추가
- lesson에서 parents 칼럼이 nullable임을 고려해 isMatchedParents 메소드 수정



<br/>


### ❄️ 주의할 점

---


<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
<img width="1248" alt="스크린샷 2023-07-19 오전 4 52 04" src="https://github.com/Gwasuwon-shot/Tutice_Server/assets/65851554/1cb958db-5967-4d49-bd13-aac62d08569e">

<img width="1248" alt="스크린샷 2023-07-19 오전 4 52 22" src="https://github.com/Gwasuwon-shot/Tutice_Server/assets/65851554/6d90ecec-afaf-4c3d-952c-5877567ecb77">
