### PR TITLE
[feat] updateScheduleAttendance

### DIFF
--- a/src/main/java/gwasuwonshot/tutice/common/exception/ErrorStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/ErrorStatus.java
@@ -25,6 +25,9 @@ public enum ErrorStatus {
     INVALID_SCHEDULE_DATE_EXCEPTION(HttpStatus.BAD_REQUEST,"출결상태가 존재하는 스케쥴 이전으로는 날짜를 변경할 수 없습니다."),
     INVALID_PAYMENT_RECORD_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 입금된 기록은 수정할 수 없습니다."),
     UNCONNECTED_LESSON_PAYMENT_RECORD_EXCEPTION(HttpStatus.BAD_REQUEST,"레슨과 입금기록이 연결되지 않았습니다."),
+    INVALID_ATTENDANCE_DATE_EXCEPTION(HttpStatus.BAD_REQUEST,"미래 출결 상태를 미리 변경할 수 없습니다."),
+    INVALID_ATTENDANCE_STATUS_EXCEPTION(HttpStatus.BAD_REQUEST,"취소 상태의 스케줄은 수정할 수 없습니다."),
+    INVALID_ATTENDANCE_SCHEDULE_EXCEPTION(HttpStatus.BAD_REQUEST,"출결이 누락된 수업 출석체크를 먼저 진행해야 합니다."),
 
 
 

--- a/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
@@ -27,6 +27,7 @@ public enum SuccessStatus {
     GET_PAYMENT_RECORD_POST_VIEW_SUCCESS(HttpStatus.OK,"입금 등록 뷰 정보 가져오기 성공"),
     UPDATE_PAYMENT_RECORD_SUCCESS(HttpStatus.OK,"입금 등록 성공"),
     GET_PAYMENT_RECORD_SUCCESS(HttpStatus.OK,"입금 내역 가져오기 성공"),
+    UPDATE_SCHEDULE_ATTENDANCE_SUCCESS(HttpStatus.OK,"출석 상태 변경 성공"),
 
 
 

--- a/src/main/java/gwasuwonshot/tutice/schedule/controller/ScheduleController.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/controller/ScheduleController.java
@@ -3,10 +3,12 @@ package gwasuwonshot.tutice.schedule.controller;
 import gwasuwonshot.tutice.common.dto.ApiResponseDto;
 import gwasuwonshot.tutice.common.exception.SuccessStatus;
 import gwasuwonshot.tutice.common.resolver.userIdx.UserIdx;
+import gwasuwonshot.tutice.schedule.dto.request.UpdateScheduleAttendanceRequestDto;
 import gwasuwonshot.tutice.schedule.dto.request.UpdateScheduleRequestDto;
 import gwasuwonshot.tutice.schedule.dto.response.GetMissingAttendanceScheduleResponseDto;
 import gwasuwonshot.tutice.schedule.dto.response.GetScheduleByUserResponseDto;
 import gwasuwonshot.tutice.schedule.dto.response.GetTodayScheduleByTeacherResponseDto;
+import gwasuwonshot.tutice.schedule.dto.response.UpdateScheduleAttendanceResponseDto;
 import gwasuwonshot.tutice.schedule.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -53,6 +55,13 @@ public class ScheduleController {
                                       @RequestBody @Valid final UpdateScheduleRequestDto request) {
   scheduleService.updateSchedule(userIdx, request);
   return ApiResponseDto.success(SuccessStatus.UPDATE_SCHEDULE);
+ }
+
+ @PatchMapping("/attendance")
+ @ResponseStatus(HttpStatus.OK)
+ public ApiResponseDto<UpdateScheduleAttendanceResponseDto> updateScheduleAttendance(@UserIdx final Long userIdx,
+                                                                                     @RequestBody @Valid final UpdateScheduleAttendanceRequestDto request) {
+  return ApiResponseDto.success(SuccessStatus.UPDATE_SCHEDULE_ATTENDANCE_SUCCESS, scheduleService.updateScheduleAttendance(userIdx, request));
  }
 
 }

--- a/src/main/java/gwasuwonshot/tutice/schedule/dto/request/ScheduleAttendance.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/dto/request/ScheduleAttendance.java
@@ -1,0 +1,20 @@
+package gwasuwonshot.tutice.schedule.dto.request;
+
+import gwasuwonshot.tutice.common.resolver.enumValue.Enum;
+import gwasuwonshot.tutice.schedule.entity.ScheduleStatus;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+public class ScheduleAttendance {
+    @NotNull(message = "스케줄 idx가 없습니다.")
+    @Min(1)
+    private Long idx;
+
+    @Enum(enumClass = ScheduleStatus.class, ignoreCase = true, message ="잘못된 status 값 입니다.")
+    private String status;
+}

--- a/src/main/java/gwasuwonshot/tutice/schedule/dto/request/UpdateScheduleAttendanceRequestDto.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/dto/request/UpdateScheduleAttendanceRequestDto.java
@@ -1,0 +1,16 @@
+package gwasuwonshot.tutice.schedule.dto.request;
+
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+public class UpdateScheduleAttendanceRequestDto {
+    @Valid
+    @NotNull(message = "스케줄 정보가 없습니다.")
+    private ScheduleAttendance schedule;
+}

--- a/src/main/java/gwasuwonshot/tutice/schedule/dto/response/UpdateScheduleAttendanceResponseDto.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/dto/response/UpdateScheduleAttendanceResponseDto.java
@@ -1,0 +1,22 @@
+package gwasuwonshot.tutice.schedule.dto.response;
+
+import gwasuwonshot.tutice.common.module.DateAndTimeConvert;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UpdateScheduleAttendanceResponseDto {
+    private boolean isLastCount;
+    private TodayResponseDto attendanceSchedule;
+
+    public static UpdateScheduleAttendanceResponseDto of(boolean isLastCount, LocalDate now) {
+        return UpdateScheduleAttendanceResponseDto.builder()
+                .isLastCount(isLastCount)
+                .attendanceSchedule(TodayResponseDto.of(DateAndTimeConvert.localDateConvertString(now), DateAndTimeConvert.localDateConvertDayOfWeek(now)))
+                .build();
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/schedule/entity/Schedule.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/entity/Schedule.java
@@ -3,7 +3,6 @@ package gwasuwonshot.tutice.schedule.entity;
 import gwasuwonshot.tutice.common.entity.AuditingTimeEntity;
 import gwasuwonshot.tutice.lesson.entity.DayOfWeek;
 import gwasuwonshot.tutice.lesson.entity.Lesson;
-import gwasuwonshot.tutice.lesson.entity.Payment;
 import gwasuwonshot.tutice.lesson.entity.RegularSchedule;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -114,6 +113,10 @@ public class Schedule extends AuditingTimeEntity {
         this.date = date;
         this.startTime = startTime;
         this.endTime = endTime;
+    }
+
+    public void updateScheduleAttendance(String status) {
+        this.status = ScheduleStatus.getScheduleStatusByValue(status);
     }
 
 }

--- a/src/main/java/gwasuwonshot/tutice/schedule/exception/InvalidAttendanceDateException.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/exception/InvalidAttendanceDateException.java
@@ -1,0 +1,10 @@
+package gwasuwonshot.tutice.schedule.exception;
+
+import gwasuwonshot.tutice.common.exception.BasicException;
+import gwasuwonshot.tutice.common.exception.ErrorStatus;
+
+public class InvalidAttendanceDateException extends BasicException {
+    public InvalidAttendanceDateException(ErrorStatus errorStatus, String message) {
+        super(errorStatus, message);
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/schedule/exception/InvalidAttendanceScheduleException.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/exception/InvalidAttendanceScheduleException.java
@@ -1,0 +1,10 @@
+package gwasuwonshot.tutice.schedule.exception;
+
+import gwasuwonshot.tutice.common.exception.BasicException;
+import gwasuwonshot.tutice.common.exception.ErrorStatus;
+
+public class InvalidAttendanceScheduleException extends BasicException {
+    public InvalidAttendanceScheduleException(ErrorStatus errorStatus, String message) {
+        super(errorStatus, message);
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/schedule/exception/InvalidAttendanceStatusException.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/exception/InvalidAttendanceStatusException.java
@@ -1,0 +1,10 @@
+package gwasuwonshot.tutice.schedule.exception;
+
+import gwasuwonshot.tutice.common.exception.BasicException;
+import gwasuwonshot.tutice.common.exception.ErrorStatus;
+
+public class InvalidAttendanceStatusException extends BasicException {
+    public InvalidAttendanceStatusException(ErrorStatus errorStatus, String message) {
+        super(errorStatus, message);
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
@@ -33,4 +33,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     boolean existsByLessonAndCycleAndStatusAndDateIsBefore(Lesson lesson, Long cycle, ScheduleStatus scheduleStatus, LocalDate now);
     boolean existsByLessonAndCycleAndStatusAndDateAndStartTimeLessThanEqualAndIdxNot(Lesson lesson, Long cycle, ScheduleStatus scheduleStatus, LocalDate date, LocalTime startTime, Long idx);
     Schedule findTopByLessonAndCycleOrderByDateDesc(Lesson lesson, Long cycle);
+    List<Schedule> findAllByLessonAndCycleOrderByDateDesc(Lesson lesson, Long cycle);
 }

--- a/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findAllByDateBetweenAndLessonInOrderByDate(LocalDate startDate, LocalDate endDate, List<Lesson> lessonList);
@@ -27,4 +26,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     Long countByLessonAndCycleAndStatusIn(Lesson lesson, Long cycle, List<ScheduleStatus> statusList);
     List<Schedule> findAllByLessonAndCycleAndStatusIn(Lesson lesson, Long cycle, List<ScheduleStatus> statusList);
     List<Schedule> findAllByLessonAndCycleAndStatusNot(Lesson lesson, Long cycle, ScheduleStatus scheduleStatus, Sort sort);
+    boolean existsByLessonAndCycleAndStatusAndDateIsBefore(Lesson lesson, Long cycle, ScheduleStatus scheduleStatus, LocalDate now);
+    boolean existsByLessonAndCycleAndStatus(Lesson lesson, Long cycle, ScheduleStatus scheduleStatus);
+    boolean existsByLessonAndCycleAndStatusAndDateAndStartTimeLessThanEqualAndIdxNot(Lesson lesson, Long cycle, ScheduleStatus scheduleStatus, LocalDate date, LocalTime startTime, Long idx);
+    Schedule findTopByLessonAndCycleOrderByDateDesc(Lesson lesson, Long cycle);
 }
+

--- a/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
@@ -287,7 +287,7 @@ public class ScheduleService {
         Schedule schedule = scheduleRepository.findById(request.getSchedule().getIdx())
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_SCHEDULE_EXCEPTION, ErrorStatus.NOT_FOUND_SCHEDULE_EXCEPTION.getMessage()));
         // 미래 스케줄은 수정 불가
-        if(schedule.getDate().isAfter(LocalDate.now())) throw new InvalidAttendanceDateException(ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION, ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION.getMessage());
+        if(schedule.getDate().isAfter(LocalDate.now()) || schedule.getDate().isEqual(LocalDate.now()) && schedule.getStartTime().isAfter(LocalTime.now())) throw new InvalidAttendanceDateException(ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION, ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION.getMessage());
         // 취소 상태에서는 수정 불가
         if(schedule.getStatus().equals(ScheduleStatus.CANCEL)) throw new InvalidAttendanceStatusException(ErrorStatus.INVALID_ATTENDANCE_STATUS_EXCEPTION, ErrorStatus.INVALID_ATTENDANCE_STATUS_EXCEPTION.getMessage());
         // 이전 스케줄 누락되면 불가

--- a/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
@@ -289,8 +289,8 @@ public class ScheduleService {
         // 스케줄 존재 여부
         Schedule schedule = scheduleRepository.findById(request.getSchedule().getIdx())
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_SCHEDULE_EXCEPTION, ErrorStatus.NOT_FOUND_SCHEDULE_EXCEPTION.getMessage()));
-        // 미래 스케줄은 수정 불가
-        if(schedule.getDate().isAfter(LocalDate.now()) || schedule.getDate().isEqual(LocalDate.now()) && schedule.getStartTime().isAfter(LocalTime.now())) throw new InvalidAttendanceDateException(ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION, ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION.getMessage());
+        // 출결 가능 이전 스케줄은 수정 불가
+        if(schedule.getDate().isAfter(LocalDate.now()) || (schedule.getDate().isEqual(LocalDate.now()) && schedule.getStartTime().isAfter(LocalTime.now()))) throw new InvalidAttendanceDateException(ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION, ErrorStatus.INVALID_ATTENDANCE_DATE_EXCEPTION.getMessage());
         // 취소 상태에서는 수정 불가
         if(schedule.getStatus().equals(ScheduleStatus.CANCEL)) throw new InvalidAttendanceStatusException(ErrorStatus.INVALID_ATTENDANCE_STATUS_EXCEPTION, ErrorStatus.INVALID_ATTENDANCE_STATUS_EXCEPTION.getMessage());
         // 이전 스케줄 누락되면 불가


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
closes #55


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- 유저 존재 / 선생님여부 / 스케줄 존재 확인
- 미래 스케줄인지 확인
- '취소' 상태인지 여부 확인 -> 취소로 한 번 바꾸면 다시 변경 불가
- 이전 스케줄 출결 누락 여부 (공통조건: lesson, cycle, status=NO_STATUS)
1. 과거
2. 현재(종료 및 시작한 시간) + 바꾸려고 요청한 스케줄은 제외
- 스케줄 업데이트 -> '취소'면 자동으로 1개 생성
- 마지막 회차 여부 체크해서 함께 반환 (입금 관련 플로우 때문에 필요)



<br/>


### ❄️ 주의할 점

---

일단 생각나는 케이스 테스트는 해봤는데, 더 많은 케이스가 있을 것 같아서 테스트 코드 작성하면서 다시 점검 하겠습니다 ,, *
