### PR TITLE
[feat] get lesson schedule by User

### DIFF
--- a/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
@@ -13,21 +13,28 @@ public enum SuccessStatus {
      */
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
     NEW_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공했습니다."),
+
+
     GET_LESSON_BY_USER_SUCCESS(HttpStatus.OK, "유저별로 연결된 수업 여부를 가져오는데 성공했습니다."),
-    GET_LESSON_DETAIL_BY_PARENTS_SUCCESS(HttpStatus.OK, "선생님이 연결된 수업의 상세정보를 가져오는데 성공했습니다."),
-    UPDATE_DEVICE_TOKEN_SUCCESS(HttpStatus.OK, "디바이스 토큰 업데이트 성공"),
-    GET_TODAY_SCHEDULE_BY_PARENTS_SUCCESS(HttpStatus.OK, "학부모 메인 뷰의 오늘의 수업 배너를 가져오는데 성공했습니다."),
-    UPDATE_LESSON_PARENTS_SUCCESS(HttpStatus.OK, "수업과 학부모 연결 성공"),
-    GET_TODAY_SCHEDULE_BY_TEACHER_SUCCESS(HttpStatus.OK, "선생님 메인 뷰의 오늘의 수업 배너를 가져오는데 성공했습니다."),
+    GET_LESSON_SCHEDULE_SUCCESS(HttpStatus.OK,"수업 내역(출결 상황) 가져오기 성공"),
     GET_SCHEDULE_BY_USER_SUCCESS(HttpStatus.OK, "스케줄 메인 뷰를 가져오는데 성공했습니다."),
     GET_MISSING_ATTENDANCE_SCHEDULE_SUCCESS(HttpStatus.OK, "선생님의 출결 누락 뷰를 가져오는데 성공했습니다."),
     GET_MISSING_MAINTENANCE_LESSON_SUCCESS(HttpStatus.OK, "연장여부를 알려주지 않은 수업 리스트 가져오기 성공"),
-    GET_LESSON_BY_PARENTS_SUCCESS(HttpStatus.OK,"학부모 메인 뷰의 수업관리 조회 성공"),
-    UPDATE_SCHEDULE(HttpStatus.OK,"스케줄 수정에 성공했습니다."),
     GET_PAYMENT_RECORD_POST_VIEW_SUCCESS(HttpStatus.OK,"입금 등록 뷰 정보 가져오기 성공"),
-    UPDATE_PAYMENT_RECORD_SUCCESS(HttpStatus.OK,"입금 등록 성공"),
     GET_PAYMENT_RECORD_SUCCESS(HttpStatus.OK,"입금 내역 가져오기 성공"),
 
+
+    GET_LESSON_DETAIL_BY_PARENTS_SUCCESS(HttpStatus.OK, "선생님이 연결된 수업의 상세정보를 가져오는데 성공했습니다."),
+    GET_TODAY_SCHEDULE_BY_PARENTS_SUCCESS(HttpStatus.OK, "학부모 메인 뷰의 오늘의 수업 배너를 가져오는데 성공했습니다."),
+    GET_LESSON_BY_PARENTS_SUCCESS(HttpStatus.OK,"학부모 메인 뷰의 수업관리 조회 성공"),
+
+    GET_TODAY_SCHEDULE_BY_TEACHER_SUCCESS(HttpStatus.OK, "선생님 메인 뷰의 오늘의 수업 배너를 가져오는데 성공했습니다."),
+
+
+    UPDATE_DEVICE_TOKEN_SUCCESS(HttpStatus.OK, "디바이스 토큰 업데이트 성공"),
+    UPDATE_LESSON_PARENTS_SUCCESS(HttpStatus.OK, "수업과 학부모 연결 성공"),
+    UPDATE_SCHEDULE(HttpStatus.OK,"스케줄 수정에 성공했습니다."),
+    UPDATE_PAYMENT_RECORD_SUCCESS(HttpStatus.OK,"입금 등록 성공"),
 
 
 

--- a/src/main/java/gwasuwonshot/tutice/lesson/controller/LessonController.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/controller/LessonController.java
@@ -10,8 +10,10 @@ import gwasuwonshot.tutice.lesson.dto.response.CreateLessonResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.GetLessonByUserResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.getLessonByParents.GetLessonByParentsResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.getLessonDetail.GetLessonDetailByParentsResponseDto;
+import gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule.GetLessonScheduleByUserResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.getMissingMaintenance.GetMissingMaintenanceLessonResponseDto;
 import gwasuwonshot.tutice.lesson.service.LessonService;
+import gwasuwonshot.tutice.user.entity.Role;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -44,6 +46,30 @@ public class LessonController {
 
         return ApiResponseDto.success(SuccessStatus.GET_LESSON_BY_USER_SUCCESS,
                 lessonService.getLessonByUser(userIdx));
+
+
+    }
+
+    @GetMapping("/schedule/parents/{lessonIdx}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetLessonScheduleByUserResponseDto> getLessonScheduleByParents(
+            @UserIdx final Long userIdx,
+            @PathVariable final Long lessonIdx) {
+
+        return ApiResponseDto.success(SuccessStatus.GET_LESSON_SCHEDULE_SUCCESS,
+                lessonService.getLessonScheduleByUser(Role.PARENTS,userIdx,lessonIdx));
+
+
+    }
+
+    @GetMapping("/schedule/teacher/{lessonIdx}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetLessonScheduleByUserResponseDto> getLessonScheduleByTeacher(
+            @UserIdx final Long userIdx,
+            @PathVariable final Long lessonIdx) {
+
+        return ApiResponseDto.success(SuccessStatus.GET_LESSON_SCHEDULE_SUCCESS,
+                lessonService.getLessonScheduleByUser(Role.TEACHER,userIdx,lessonIdx));
 
 
     }

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonSchedule.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonSchedule.java
@@ -1,0 +1,24 @@
+package gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule;
+
+import gwasuwonshot.tutice.lesson.dto.response.getLessonDetail.GetLessonDetailByParentsResponseAccount;
+import gwasuwonshot.tutice.lesson.dto.response.getLessonDetail.GetLessonDetailByParentsResponseDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetLessonSchedule {
+    private Long idx;
+    private String date;
+    private String status;
+    private String startTime;
+    private String endTime;
+
+    public static GetLessonSchedule of(Long idx, String date, String status, String startTime, String endTime) {
+        return new GetLessonSchedule(idx, date, status,startTime,endTime);
+
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByParents.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByParents.java
@@ -1,0 +1,25 @@
+package gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetLessonScheduleByParents implements GetLessonScheduleByUser{
+    private Long idx;
+    private String studentName;
+    private String teacherName;
+    private String subject;
+    private Long count;
+    private Long nowCount;
+    private Long percent;
+
+    public static GetLessonScheduleByParents of(Long idx,String studentName,String teacherName,
+                                                String subject, Long count,Long nowCount, Long percent ) {
+        return new GetLessonScheduleByParents(idx, studentName, teacherName,subject,count,nowCount,percent);
+
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByTeacher.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByTeacher.java
@@ -1,0 +1,25 @@
+package gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetLessonScheduleByTeacher implements GetLessonScheduleByUser{
+    private Long idx;
+    private String studentName;
+    private String subject;
+    private Long count;
+    private Long nowCount;
+    private Long percent;
+
+    public static GetLessonScheduleByTeacher of(Long idx,String studentName, String subject,
+                                                Long count,Long nowCount, Long percent ) {
+        return new GetLessonScheduleByTeacher(idx, studentName, subject,count,nowCount,percent);
+
+    }
+}
+

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByUser.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByUser.java
@@ -1,0 +1,4 @@
+package gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule;
+
+public interface GetLessonScheduleByUser {
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByUserResponseDto.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/dto/response/getLessonSchedule/GetLessonScheduleByUserResponseDto.java
@@ -1,0 +1,22 @@
+package gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetLessonScheduleByUserResponseDto {
+    private GetLessonScheduleByUser lesson;
+    private List<GetLessonSchedule> scheduleList;
+
+    public static GetLessonScheduleByUserResponseDto of(GetLessonScheduleByUser lesson,
+                                                        List<GetLessonSchedule> scheduleList){
+        return new GetLessonScheduleByUserResponseDto(lesson, scheduleList);
+
+    }
+}

--- a/src/main/java/gwasuwonshot/tutice/lesson/entity/Lesson.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/entity/Lesson.java
@@ -110,7 +110,9 @@ public class Lesson extends AuditingTimeEntity {
     }
 
     public void finishLesson(){this.isFinished=true;}
+
     public Boolean isMatchedParents(User parents){
+        if(this.getParents() == null ){return false;}
         return this.getParents().equals(parents);
     }
 

--- a/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
@@ -11,6 +11,10 @@ import gwasuwonshot.tutice.lesson.dto.response.*;
 import gwasuwonshot.tutice.lesson.dto.response.getLessonByParents.GetLessonByParents;
 import gwasuwonshot.tutice.lesson.dto.response.getLessonDetail.GetLessonDetailByParentsResponseAccount;
 import gwasuwonshot.tutice.lesson.dto.response.getLessonDetail.GetLessonDetailByParentsResponseDto;
+import gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule.GetLessonSchedule;
+import gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule.GetLessonScheduleByParents;
+import gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule.GetLessonScheduleByTeacher;
+import gwasuwonshot.tutice.lesson.dto.response.getLessonSchedule.GetLessonScheduleByUserResponseDto;
 import gwasuwonshot.tutice.lesson.dto.response.getMissingMaintenance.GetMissingMaintenanceLesson;
 import gwasuwonshot.tutice.lesson.dto.response.getMissingMaintenance.MissingMaintenanceLesson;
 import gwasuwonshot.tutice.lesson.entity.*;
@@ -58,6 +62,78 @@ public class LessonService {
     private final PaymentRecordRepository paymentRecordRepository;
     private final ScheduleRepository scheduleRepository;
 
+
+    @Transactional
+    public GetLessonScheduleByUserResponseDto getLessonScheduleByUser(Role role,Long userIdx, Long lessonIdx){
+//
+//        유저가 학부모인지확인
+        User user = userRepository.findById(userIdx)
+                .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        if(!user.isMatchedRole(role)){
+            throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
+        }
+
+//        레슨이 존재하는지와 레슨과학부모가 연결되어있는지 확인
+        // 레슨의 존재확인
+        Lesson lesson=lessonRepository.findById(lessonIdx)
+                .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
+
+        // 레슨과 유저의 연결성확인
+        if(role.equals(Role.PARENTS)){
+            if(!lesson.isMatchedParents(user)){
+                throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
+            }
+
+        } else if (role.equals(Role.TEACHER)) {
+            if(!lesson.isMatchedTeacher(user)){
+                throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
+            }
+
+        }
+        else {
+            throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
+        }
+
+
+
+//        레슨정보구성
+        // TODO : nowCount - percent 로직 겹침. 모듈로 빼기
+//        - [ ] nowCount : 진짜 카운트 : 현재 사이클의 스케쥴중 출결정보가 있는스케쥴개수
+        Long nowCount = scheduleRepository.countByLessonAndCycleAndStatusIn(lesson,lesson.getCycle(),ScheduleStatus.getAttendanceScheduleStatusList());
+        //                - [ ] percent : 전체카운트와 진짜카운트의 백분율
+        Long percent = ReturnLongMath.getPercentage(nowCount,lesson.getCount());
+//           레슨스케쥴정보구성
+        List<GetLessonSchedule> getLessonScheduleList=new ArrayList<>();
+        scheduleRepository.findAllByLessonAndCycleOrderByDateDesc(lesson,lesson.getCycle())
+                .forEach(s->{
+                    getLessonScheduleList.add(
+                            GetLessonSchedule.of(
+                                    s.getIdx(),
+                                    DateAndTimeConvert.localDateConvertString(s.getDate()),
+                                    s.getStatus().getValue(),
+                                    DateAndTimeConvert.localTimeConvertString(s.getStartTime()),
+                                    DateAndTimeConvert.localTimeConvertString(s.getEndTime())));
+                });
+
+        if(role.equals(Role.PARENTS)){
+            return GetLessonScheduleByUserResponseDto.of(
+                    GetLessonScheduleByParents.of(lesson.getIdx(),lesson.getStudentName(),lesson.getTeacher().getName(),lesson.getSubject(), lesson.getCount(), nowCount,percent),
+                    getLessonScheduleList
+            );
+
+        } else if (role.equals(Role.TEACHER)) {
+            return GetLessonScheduleByUserResponseDto.of(
+                    GetLessonScheduleByTeacher.of(lesson.getIdx(),lesson.getStudentName(),lesson.getSubject(), lesson.getCount(), nowCount,percent),
+                    getLessonScheduleList
+            );
+
+        }
+        else {
+            return null;
+        }
+
+    }
 
     @Transactional
     public GetLessonDetailByParentsResponseDto getLessonDetailByParents(Long userIdx, Long lessonIdx){
@@ -134,6 +210,7 @@ public class LessonService {
                     //  현재 회차계산 : 이때 수업에 연결된 스케쥴중 현재사이클(수업에 연결된 paymentRecord개수(선불,후불+1))중 출석,결석만 카운트해서 현재카운트가져오기
 
 
+                    // TODO : nowCount - percent 로직 겹침. 모듈로 빼기
                     Long nowCount = scheduleRepository.countByLessonAndCycleAndStatusIn(pl,pl.getCycle(),ScheduleStatus.getAttendanceScheduleStatusList());
                     Long percent = ReturnLongMath.getPercentage(nowCount,pl.getCount());
                     getLessonByParentsList.add(

--- a/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/repository/ScheduleRepository.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    List<Schedule> findAllByLessonAndCycleOrderByDateDesc(Lesson lesson, Long cycle);
     List<Schedule> findAllByDateBetweenAndLessonInOrderByDate(LocalDate startDate, LocalDate endDate, List<Lesson> lessonList);
     List<Schedule> findAllByDateAndLessonIn(LocalDate now, List<Lesson> lessonList);
     List<Schedule> findAllByDateAndLessonInOrderByStartTime(LocalDate now, List<Lesson> lessonList);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
closes #84 


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

-  선생님, 부모님 한번에 구현
- 같은 서비스 메소드 사용, 컨트롤러만 분리
- 서비스로직
    -  유저확인 역할확인
    - 레슨확인 유저와 연결된레슨인지확인
    - 레슨의 현재 진짜회차 확인
    - 레슨의 현재스케쥴리스트 최신순으로 가져오기



<br/>


### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
