### PR TITLE
[fix] checkDuplicationEmail 성공 및 실패 메시지 변경

### DIFF
--- a/src/main/java/gwasuwonshot/tutice/common/exception/ErrorStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/ErrorStatus.java
@@ -62,7 +62,7 @@ public enum ErrorStatus {
     ALREADY_EXIST_USER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 유저입니다"),
     ALREADY_EXIST_LESSON_PARENTS_EXCEPTION(HttpStatus.CONFLICT, "이미 학부모가 등록된 수업입니다."),
     ALREADY_FINISHED_LESSON_EXCEPTION(HttpStatus.CONFLICT, "이미 종료된 수업입니다."),
-    ALREADY_EXIST_EMAIL_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    ALREADY_EXIST_EMAIL_EXCEPTION(HttpStatus.CONFLICT, "이미 사용 중인 이메일 입니다."),
 
 
     /**

--- a/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
+++ b/src/main/java/gwasuwonshot/tutice/common/exception/SuccessStatus.java
@@ -15,7 +15,7 @@ public enum SuccessStatus {
     NEW_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공했습니다."),
     GET_TODAY_DATE_SUCCESS(HttpStatus.OK,"오늘 날짜와 요일을 가져오는데 성공했습니다."),
     GET_USER_NAME_SUCCESS(HttpStatus.OK, "유저 이름을 가져오는데 성공했습니다."),
-    CHECK_DUPLICATION_EMAIL_SUCCESS(HttpStatus.OK, "이메일이 중복되지 않습니다."),
+    CHECK_DUPLICATION_EMAIL_SUCCESS(HttpStatus.OK, "사용 가능한 이메일 입니다."),
 
 
     GET_LESSON_EXISTENCE_BY_USER_SUCCESS(HttpStatus.OK, "유저별로 연결된 수업 여부를 가져오는데 성공했습니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
closes #155 


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- 디자인에 따라 클라 요청으로 성공 및 실패 메시지 변경!



<br/>


### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
