### PR TITLE
[hotfix]delete lesson

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ ex. [feat] searchPublicCourse -->
 
 ---
 <!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
-closes #<!-- 번호 -->
+close #<!-- 번호 -->
 
 
 <br/>

--- a/src/main/java/gwasuwonshot/tutice/common/entity/AuditingTimeEntity.java
+++ b/src/main/java/gwasuwonshot/tutice/common/entity/AuditingTimeEntity.java
@@ -15,7 +15,6 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class AuditingTimeEntity {
 
-    // TODO : 어째서인지는 모르지만 createAt, updateAt이 우리 서비스에서는 적용이 안되고 있음
     @CreatedDate
     private LocalDateTime createdAt;
 
@@ -35,6 +34,9 @@ public abstract class AuditingTimeEntity {
     public void preUpdate(){
         updatedAt = LocalDateTime.now();
     }
+
+
+    public void markAsDeleted(){deletedAt=LocalDateTime.now();}
 }
 
 

--- a/src/main/java/gwasuwonshot/tutice/lesson/entity/Lesson.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/entity/Lesson.java
@@ -118,6 +118,8 @@ public class Lesson extends AuditingTimeEntity {
     }
     public void finishLesson(){this.isFinished=true;}
 
+    public void deleteLesson(){ super.markAsDeleted();}
+
     public Boolean isMatchedParents(User parents){
         if(this.getParents() == null ){return false;}
         return this.getParents().equals(parents);

--- a/src/main/java/gwasuwonshot/tutice/lesson/repository/LessonRepository.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/repository/LessonRepository.java
@@ -8,10 +8,13 @@ import java.util.Optional;
 
 public interface LessonRepository extends JpaRepository<Lesson, Long> {
 
-    List<Lesson> findAllByParentsIdxAndIsFinished(Long parentsIdx, Boolean isFinished);
+    List<Lesson> findAllByParentsIdxAndIsFinishedAndDeletedAtIsNull(Long parentsIdx, Boolean isFinished);
 
-    List<Lesson> findAllByTeacherIdxAndIsFinished(Long teacherIdx, Boolean isFinished);
-    Optional<Lesson> findByIdxAndIsFinished(Long lessonIdx, boolean isFinished);
+    List<Lesson> findAllByTeacherIdxAndIsFinishedAndDeletedAtIsNull(Long teacherIdx, Boolean isFinished);
+    Optional<Lesson> findByIdxAndIsFinishedAndDeletedAtIsNull(Long lessonIdx, boolean isFinished);
+
+    Optional<Lesson> findByIdxAndDeletedAtIsNull(Long lessonIdx);
+
 
 }
 

--- a/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
@@ -418,10 +418,12 @@ public class LessonService {
         // 유저 존재 여부 확인
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findByIdxAndDeletedAtIsNull(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
-        // 수업과 유저 연결 여부 확인
+
+         // 수업과 유저 연결 여부 확인
         if (!lesson.isMatchedUser(user))
             throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
 
@@ -437,9 +439,13 @@ public class LessonService {
         // 유저 존재 여부 확인
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findByIdxAndDeletedAtIsNull(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
+
+
+
         // 수업과 유저 연결 여부 확인
         if (!lesson.isMatchedUser(user))
             throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
@@ -493,9 +499,14 @@ public class LessonService {
         // 유저 존재 여부 확인
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findByIdxAndDeletedAtIsNull(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
+
+
+
         // 수업과 유저 연결 여부 확인
         if (!lesson.isMatchedUser(user))
             throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
@@ -554,9 +565,13 @@ public class LessonService {
         // 선생님 여부
         if(!user.isMatchedRole(Role.TEACHER)) throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
 
+
+
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findByIdxAndDeletedAtIsNull(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
+
+
         // 수업과 유저 연결 여부 확인
         if (!lesson.isMatchedUser(user))
             throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());

--- a/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
@@ -93,23 +93,19 @@ public class LessonService {
             throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
         }
 
-//        유저에 연결된 레슨리스트 다가져오기
+
+        // 유저에 연결된 레슨리스트 다가져오기
         teacher.getLessonList().forEach(l->{
 
-// 먼저 레슨이 종료되었는지(삭제되었는지) 확인
+            // 먼저 레슨이 삭제되었는지 확인
             if(l.getDeletedAt()!=null){
                 return;
             }
 
-////        각레슨의 정기스케쥴 가져와 일주일순서로 정렬
-//            List<String> dayOfWeekList = new ArrayList<>();
-//            RegularSchedule.dayOfWeekSortedReglarScheduleList(l.getRegularScheduleList());
-//            l.getRegularScheduleList()
-//                    .forEach(rs->dayOfWeekList.add(rs.getDayOfWeek().getValue()));
-            // 23.10.18 수정본 : 각수업당 다가오는 가장 빠른 요일가져오기
+            // 각수업당 다가오는 가장 빠른 요일가져오기
             RegularSchedule latestRegularSchedule = RegularSchedule.findLatestRegularSchedule(LocalDate.now(),l.getRegularScheduleList());
 
-//        각레슨의 진짜회차를 계산해 percent 계산
+            //  각레슨의 진짜회차를 계산해 percent 계산
             // TODO : nowCount - percent 로직 겹침. 모듈로 빼기
 //        - [ ] nowCount : 진짜 카운트 : 현재 사이클의 스케쥴중 출결정보가 있는스케쥴개수
             Long nowCount = scheduleRepository.countByLessonAndCycleAndStatusIn(l,l.getCycle(),ScheduleStatus.getAttendanceScheduleStatusList());

--- a/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/service/LessonService.java
@@ -557,11 +557,7 @@ public class LessonService {
         if (!lesson.isMatchedUser(user))
             throw new InvalidLessonException(ErrorStatus.INVALID_LESSON_EXCEPTION, ErrorStatus.INVALID_LESSON_CODE_EXCEPTION.getMessage());
 
-        // 수업이 이미 종료되었는지 확인
-        if(lesson.getIsFinished()){
-            throw new AlreadyFinishedLessonException(ErrorStatus.ALREADY_FINISHED_LESSON_EXCEPTION,ErrorStatus.ALREADY_FINISHED_LESSON_EXCEPTION.getMessage());
-        }
-        // 수업 종료처리
-        lesson.finishLesson();
+        // 수업 삭제 처리
+        lesson.deleteLesson();
     }
 }

--- a/src/main/java/gwasuwonshot/tutice/lesson/service/PaymentRecordService.java
+++ b/src/main/java/gwasuwonshot/tutice/lesson/service/PaymentRecordService.java
@@ -74,7 +74,7 @@ public class PaymentRecordService {
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findByIdxAndDeletedAtIsNull(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
         // 수업과 유저 연결 여부 확인
         if (!lesson.isMatchedUser(user))

--- a/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
@@ -449,7 +449,7 @@ public class ScheduleService {
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findByIdxAndDeletedAtIsNull(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
         // 수업과 유저 연결 여부 확인
         if (!lesson.isMatchedUser(user))

--- a/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
+++ b/src/main/java/gwasuwonshot/tutice/schedule/service/ScheduleService.java
@@ -66,7 +66,7 @@ public class ScheduleService {
 
         // 학부모-레슨리스트 -> 스케줄 중 해당 레슨 있는지 + 오늘 날짜인지
         // TODO 부모님 수업 리스트 양방향 매핑으로 수정하기
-        List<Lesson> lessonList = lessonRepository.findAllByParentsIdxAndIsFinished(userIdx,false);
+        List<Lesson> lessonList = lessonRepository.findAllByParentsIdxAndIsFinishedAndDeletedAtIsNull(userIdx,false);
         List<Schedule> todayScheduleList = scheduleRepository.findAllByDateAndLessonIn(now, lessonList);
         if(todayScheduleList == null) return GetTodayScheduleByParentsResponseDto.of(user.getName());
         return GetTodayScheduleByParentsResponseDto.ofTodaySchedule(user.getName(), now, todayScheduleList);
@@ -85,9 +85,9 @@ public class ScheduleService {
         // 유저 역할 따라 스케줄 가져오기
         List<Lesson> lessonList;
         if (user.isMatchedRole(Role.PARENTS)) {
-            lessonList = lessonRepository.findAllByParentsIdxAndIsFinished(userIdx,false);
+            lessonList = lessonRepository.findAllByParentsIdxAndIsFinishedAndDeletedAtIsNull(userIdx,false);
         } else if (user.isMatchedRole(Role.TEACHER)) {
-            lessonList = lessonRepository.findAllByTeacherIdxAndIsFinished(userIdx,false);
+            lessonList = lessonRepository.findAllByTeacherIdxAndIsFinishedAndDeletedAtIsNull(userIdx,false);
         } else {
             return null;
         }
@@ -128,7 +128,7 @@ public class ScheduleService {
 
         // 오늘의 수업 있는지 체크
         LocalDate now = LocalDate.now();
-        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinished(userIdx,false);
+        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinishedAndDeletedAtIsNull(userIdx,false);
         List<Schedule> todayScheduleList = scheduleRepository.findAllByDateAndLessonInOrderByStartTime(now, lessonList);
 
         // 오늘의 수업 유무
@@ -229,7 +229,7 @@ public class ScheduleService {
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
-        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinished(userIdx,false);
+        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinishedAndDeletedAtIsNull(userIdx,false);
 
         // 오늘 수업 시작&끝 체크 안 한 것
         List<Schedule> missingScheduleList = scheduleRepository.findAllByStatusAndDateAndStartTimeIsBeforeAndLessonIn(ScheduleStatus.NO_STATUS, LocalDate.now(), LocalTime.now(), lessonList);
@@ -324,7 +324,7 @@ public class ScheduleService {
         // 선생님 여부
         if(!user.isMatchedRole(Role.TEACHER)) throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
         // 가장 최근 스케줄 가져오기 (오늘 포함)
-        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinished(userIdx, false);
+        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinishedAndDeletedAtIsNull(userIdx, false);
         List<Schedule> scheduleList = scheduleRepository.findAllByLessonInAndDateGreaterThanEqualOrderByDate(lessonList, LocalDate.now());
         // 오늘인지 체크
         if(scheduleList.isEmpty()) return null;
@@ -402,7 +402,7 @@ public class ScheduleService {
         if(!user.isMatchedRole(Role.TEACHER)) throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
 
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findByIdxAndIsFinished(lessonIdx, false)
+        Lesson lesson = lessonRepository.findByIdxAndIsFinishedAndDeletedAtIsNull(lessonIdx, false)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
 
         // 출석누락 유무
@@ -420,7 +420,7 @@ public class ScheduleService {
         // 선생님 여부
         if(!user.isMatchedRole(Role.TEACHER)) throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
         // 수업 리스트 가져오기
-        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinished(userIdx, false);
+        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinishedAndDeletedAtIsNull(userIdx, false);
         // 출석누락 유무
         boolean isMissingAttendance = false;
         boolean isAfterMissingAttendance = scheduleRepository.existsByStatusAndDateIsBeforeAndLessonIn(ScheduleStatus.NO_STATUS, LocalDate.now(), lessonList);
@@ -438,7 +438,7 @@ public class ScheduleService {
         // 선생님 여부
         if(!user.isMatchedRole(Role.TEACHER)) throw new InvalidRoleException(ErrorStatus.INVALID_ROLE_EXCEPTION,ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
         // 수업 리스트 가져오기
-        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinished(userIdx, false);
+        List<Lesson> lessonList = lessonRepository.findAllByTeacherIdxAndIsFinishedAndDeletedAtIsNull(userIdx, false);
         // TODO 성능 고민 (queryDSL, exists)
         List<Schedule> scheduleList = scheduleRepository.findAllByLessonInAndDate(lessonList, LocalDate.now());
         return !scheduleList.isEmpty();

--- a/src/main/java/gwasuwonshot/tutice/user/service/UserService.java
+++ b/src/main/java/gwasuwonshot/tutice/user/service/UserService.java
@@ -94,7 +94,7 @@ public class UserService {
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
         // 수업 존재 여부 확인
-        Lesson lesson = lessonRepository.findById(lessonIdx)
+        Lesson lesson = lessonRepository.findByIdxAndDeletedAtIsNull(lessonIdx)
                 .orElseThrow(() -> new NotFoundLessonException(ErrorStatus.NOT_FOUND_LESSON_EXCEPTION, ErrorStatus.NOT_FOUND_LESSON_EXCEPTION.getMessage()));
         // 수업과 유저 연결 여부 확인
         if (!lesson.isMatchedUser(user))


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #174 


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- lesson domain에 deleteLesson 메소드 생성
    -  이때 deleteAt은 추상클래스의 private 필드라서 직접접근 불가 -> 추상클래스에 markAsDeleted라는 메소드 생성
- lesson을 db에서 불러올때 DeletedAtIsNull 추가
    - lessonRepository의 메소드에 DeletedAtIsNull을 추가하고
    - 일반 findById를 사용하는 경우 findByIdxAndDeletedAtIsNull 또는 findByIdxAndIsFinishedAndDeletedAtIsNull 을 사용하도록 변경



<br/>


### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
