### PR TITLE
[feat] login, tempSignUp

### DIFF
--- a/src/main/java/gwasuwonshot/tutice/common/dto/ApiResponse.java
+++ b/src/main/java/gwasuwonshot/tutice/common/dto/ApiResponse.java
@@ -26,11 +26,7 @@ public class ApiResponse<T> {
         return new ApiResponse<T>(successStatus.getHttpStatusCode(), successStatus.getMessage(), data);
     }
 
-    public static ApiResponse error(ErrorStatus errorStatu) {
-        return new ApiResponse<>(errorStatu.getHttpStatusCode(), errorStatu.getMessage());
-    }
-
-    public static ApiResponse error(ErrorStatus errorStatus, String message) {
-        return new ApiResponse<>(errorStatus.getHttpStatusCode(), message);
+    public static <T> ApiResponse<T> error(ErrorStatus errorStatus, T data) {
+        return new ApiResponse<T>(errorStatus.getHttpStatusCode(), errorStatus.getMessage(), data);
     }
 }

--- a/src/main/java/gwasuwonshot/tutice/user/controller/AuthController.java
+++ b/src/main/java/gwasuwonshot/tutice/user/controller/AuthController.java
@@ -1,10 +1,12 @@
 package gwasuwonshot.tutice.user.controller;
 
 import gwasuwonshot.tutice.common.dto.ApiResponse;
+import gwasuwonshot.tutice.common.exception.ErrorStatus;
 import gwasuwonshot.tutice.common.exception.SuccessStatus;
 import gwasuwonshot.tutice.user.dto.request.CheckDuplicationEmailRequest;
 import gwasuwonshot.tutice.user.dto.request.LocalLoginRequest;
 import gwasuwonshot.tutice.user.dto.request.LocalSignUpRequest;
+import gwasuwonshot.tutice.user.dto.request.LoginRequest;
 import gwasuwonshot.tutice.user.dto.response.LoginResponse;
 import gwasuwonshot.tutice.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,13 @@ public class AuthController {
     public ApiResponse checkDuplicationEmail(@RequestBody @Valid final CheckDuplicationEmailRequest request) {
         userService.checkDuplicationEmail(request);
         return ApiResponse.success(SuccessStatus.CHECK_DUPLICATION_EMAIL_SUCCESS);
+    }
+
+    @PostMapping("/login")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid final LoginRequest request) {
+        if(userService.isUser(request)) return ApiResponse.success(SuccessStatus.LOGIN_SUCCESS, userService.login(request));
+        else return ApiResponse.error(ErrorStatus.NOT_FOUND_USER_EXCEPTION, userService.tempSignUp(request));
     }
 
 }

--- a/src/main/java/gwasuwonshot/tutice/user/dto/request/LoginRequest.java
+++ b/src/main/java/gwasuwonshot/tutice/user/dto/request/LoginRequest.java
@@ -1,0 +1,21 @@
+package gwasuwonshot.tutice.user.dto.request;
+
+import gwasuwonshot.tutice.common.resolver.enumValue.Enum;
+import gwasuwonshot.tutice.user.entity.Provider;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank
+    private String socialToken;
+
+    @NotBlank
+    @Enum(enumClass = Provider.class, ignoreCase = true, message = "잘못된 provider 값 입니다.")
+    private String provider;
+
+}

--- a/src/main/java/gwasuwonshot/tutice/user/dto/response/LoginResponse.java
+++ b/src/main/java/gwasuwonshot/tutice/user/dto/response/LoginResponse.java
@@ -1,5 +1,6 @@
 package gwasuwonshot.tutice.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import gwasuwonshot.tutice.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LoginResponse {
     private String accessToken;
     private String refreshToken;
@@ -16,5 +18,9 @@ public class LoginResponse {
 
     public static LoginResponse of(String accessToken, String refreshToken, User user) {
         return new LoginResponse(accessToken, refreshToken, UserResponse.of(user.getName(), user.getRole().getValue()));
+    }
+
+    public static LoginResponse of(String accessToken, String refreshToken) {
+        return new LoginResponse(accessToken, refreshToken, null);
     }
 }

--- a/src/main/java/gwasuwonshot/tutice/user/entity/Provider.java
+++ b/src/main/java/gwasuwonshot/tutice/user/entity/Provider.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 @Getter
 @RequiredArgsConstructor
 public enum Provider implements EnumModel {
+    LOCAL("PROVIDER_LOCAL", "자체"),
     KAKAO("PROVIDER_KAKAO","카카오"),
     NAVER("PROVIDER_NAVER","네이버"),
     TEMP("PROVIDER_TEMP","임시");

--- a/src/main/java/gwasuwonshot/tutice/user/entity/User.java
+++ b/src/main/java/gwasuwonshot/tutice/user/entity/User.java
@@ -29,22 +29,17 @@ public class User extends AuditingTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    @Column(nullable = false, name = "email")
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "provider", nullable = false)
     private Provider provider = Provider.TEMP;
 
-    @Column(nullable = false)
     private String socialToken;
 
-    @Column(nullable = false)
     private String phoneNumber;
 
     private String password;
 
-    @Column(nullable = false)
     private String name;
 
     private String deviceToken;
@@ -52,7 +47,6 @@ public class User extends AuditingTimeEntity {
     private Boolean isMarketing;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Role role;
 
     @OneToMany(mappedBy = "teacher", cascade = {CascadeType.REMOVE})
@@ -77,6 +71,13 @@ public class User extends AuditingTimeEntity {
                 .build();
     }
 
+    public static User toEntity(String socialToken, Provider provider) {
+        return User.builder()
+                .socialToken(socialToken)
+                .provider(provider)
+                .build();
+    }
+
     public void addAccount(Account account){
         accountList.add(account);
     }
@@ -91,7 +92,8 @@ public class User extends AuditingTimeEntity {
 
     @Builder
     public User(String email, Provider provider, String password,
-                String name, String deviceToken, Role role, Boolean isMarketing){
+                String name, String deviceToken, Role role, Boolean isMarketing,
+                String socialToken, String phoneNumber){
         this.email = email;
         this.provider = provider;
         this.password=password;
@@ -99,6 +101,8 @@ public class User extends AuditingTimeEntity {
         this.deviceToken = deviceToken;
         this.role=role;
         this.isMarketing=isMarketing;
+        this.socialToken = socialToken;
+        this.phoneNumber = phoneNumber;
         this.accountList=new ArrayList<>();
         this.lessonList=new ArrayList<>();
         this.notificationLogList = new ArrayList<>();

--- a/src/main/java/gwasuwonshot/tutice/user/repository/UserRepository.java
+++ b/src/main/java/gwasuwonshot/tutice/user/repository/UserRepository.java
@@ -11,4 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    Optional<User> findBySocialTokenAndProvider(String socialToken, Provider provider);
+
+    boolean existsBySocialTokenAndProviderAndNameIsNotNull(String socialToken, Provider provider);
 }

--- a/src/main/java/gwasuwonshot/tutice/user/service/UserService.java
+++ b/src/main/java/gwasuwonshot/tutice/user/service/UserService.java
@@ -2,15 +2,12 @@ package gwasuwonshot.tutice.user.service;
 
 import gwasuwonshot.tutice.common.exception.ErrorStatus;
 import gwasuwonshot.tutice.config.jwt.JwtService;
-import gwasuwonshot.tutice.user.dto.response.GetAccountByLessonResponse;
 import gwasuwonshot.tutice.lesson.entity.Lesson;
 import gwasuwonshot.tutice.lesson.exception.invalid.InvalidLessonException;
 import gwasuwonshot.tutice.lesson.exception.notfound.NotFoundLessonException;
 import gwasuwonshot.tutice.lesson.repository.LessonRepository;
-import gwasuwonshot.tutice.user.dto.request.CheckDuplicationEmailRequest;
-import gwasuwonshot.tutice.user.dto.request.LocalLoginRequest;
-import gwasuwonshot.tutice.user.dto.request.LocalSignUpRequest;
-import gwasuwonshot.tutice.user.dto.request.UpdateUserDeviceTokenRequest;
+import gwasuwonshot.tutice.user.dto.request.*;
+import gwasuwonshot.tutice.user.dto.response.GetAccountByLessonResponse;
 import gwasuwonshot.tutice.user.dto.response.GetUserNameResponse;
 import gwasuwonshot.tutice.user.dto.response.LoginResponse;
 import gwasuwonshot.tutice.user.entity.Provider;
@@ -113,5 +110,30 @@ public class UserService {
         User user = userRepository.findById(userIdx)
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
         jwtService.logout(userIdx);
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findBySocialTokenAndProvider(request.getSocialToken(), Provider.getProviderByValue(request.getProvider()))
+                .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        String accessToken = jwtService.issuedAccessToken(String.valueOf(user.getIdx()));
+        String refreshToken = jwtService.issuedRefreshToken(String.valueOf(user.getIdx()));
+
+        return LoginResponse.of(accessToken, refreshToken, user);
+    }
+
+    public boolean isUser(LoginRequest request) {
+        // 이탈 유저 체크까지
+        return userRepository.existsBySocialTokenAndProviderAndNameIsNotNull(request.getSocialToken(), Provider.getProviderByValue(request.getProvider()));
+    }
+
+    public LoginResponse tempSignUp(LoginRequest request) {
+        User newUser = userRepository.findBySocialTokenAndProvider(request.getSocialToken(), Provider.getProviderByValue(request.getProvider()))
+                .orElseGet(() -> userRepository.save(User.toEntity(request.getSocialToken(), Provider.getProviderByValue(request.getProvider()))));
+
+        String accessToken = jwtService.issuedAccessToken(String.valueOf(newUser.getIdx()));
+        String refreshToken = jwtService.issuedRefreshToken(String.valueOf(newUser.getIdx()));
+
+        return LoginResponse.of(accessToken, refreshToken);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #202


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---
[클라와 논의한 로직](https://tutice.slack.com/archives/C06QNRKS8AE/p1712404689677029)

1. isUser 통해 유저 여부 및 이탈 유저 여부 검증
(*이탈 유저 = 소셜 접근 후, 회원가입 절차에서 이탈한 경우)

2-1. 기존 유저인 경우 -> 로그인(토큰 발행)
2-2. 신규 유저인 경우 -> 회원가입(토큰 발행)


<br/>


### ❄️ 주의할 점

---

- 이탈 유저 검증을 위해, 우선 name NULL 여부로 체크했는데 좀 더 확실한 개선 방안을 고민중입니다 !
- 현재 기존 유저의 로컬 로그인과 소셜 로그인 모두 정상작동 해야 하는 관계로, User Entity의 NOT NULL 설정 임의로 해제했습니다.
(추후, 클라에서 개발 완료될 시 수정하겠습니다!)
